### PR TITLE
Fix typo breaking link reference in .md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ of them for ease of use:
 - [Rail network model
   Doncaster](https://github.com/anisotropi4/parenx/blob/main/data/rnet_doncaster_rail.geojson)
 - [Rail Data Marketplace](https://raildata.org.uk) requires registration
-- \[World Population data\[(https://hub.worldpop.org/)
-- \[Global Human Settlement Layer
-  data\[(https://publications.jrc.ec.europa.eu/repository/handle/JRC115586)
+- \[World Population data\]https://hub.worldpop.org/)
+- [Global Human Settlement Layer
+  data](https://publications.jrc.ec.europa.eu/repository/handle/JRC115586)
 
 # Hack ideas
 

--- a/README.qmd
+++ b/README.qmd
@@ -65,7 +65,7 @@ Although these datasets are available nationally we will provide subsets of them
 - [OpenStreetMap Princes Street, Edinburgh](https://github.com/anisotropi4/parenx/blob/main/data/osm_leeds.geojson)
 - [Rail network model Doncaster](https://github.com/anisotropi4/parenx/blob/main/data/rnet_doncaster_rail.geojson)
 - [Rail Data Marketplace](https://raildata.org.uk) requires registration
-- [World Population data]https://hub.worldpop.org/)
+- [World Population data](https://hub.worldpop.org/)
 - [Global Human Settlement Layer data](https://publications.jrc.ec.europa.eu/repository/handle/JRC115586)
 
 # Hack ideas

--- a/README.qmd
+++ b/README.qmd
@@ -65,8 +65,8 @@ Although these datasets are available nationally we will provide subsets of them
 - [OpenStreetMap Princes Street, Edinburgh](https://github.com/anisotropi4/parenx/blob/main/data/osm_leeds.geojson)
 - [Rail network model Doncaster](https://github.com/anisotropi4/parenx/blob/main/data/rnet_doncaster_rail.geojson)
 - [Rail Data Marketplace](https://raildata.org.uk) requires registration
-- [World Population data[(https://hub.worldpop.org/)
-- [Global Human Settlement Layer data[(https://publications.jrc.ec.europa.eu/repository/handle/JRC115586)
+- [World Population data]https://hub.worldpop.org/)
+- [Global Human Settlement Layer data](https://publications.jrc.ec.europa.eu/repository/handle/JRC115586)
 
 # Hack ideas
 


### PR DESCRIPTION
- bring history back
- original invite
- hack date
- Update README.md
- update with suggestions
- update based on #6 merge issue
- Update README.qmd
- update README.md
- typo breaking link reference in .md file
